### PR TITLE
infinite while loop fix write() and clientWrite()

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -51,12 +51,12 @@ size_t BearSSLClient::write(const uint8_t *buf, size_t size)
   while (written < size) {
     int result = br_sslio_write(&_ioc, buf, size);
 
-	if (result < 0) {
-	  break;
-	}
+    if (result < 0) {
+      break;
+    }
 
-	buf += result;
-	written += result;
+    buf += result;
+    written += result;
   }
 
   if (written == size && br_sslio_flush(&_ioc) < 0) {


### PR DESCRIPTION
Reimplemented return logic in BearSSLClient::write() and BearSSLClient::clientWrite() in  order to avoid infinite loop in https://github.com/Rocketct/ArduinoBearSSL/blob/master/src/bearssl/ssl_io.c#L279 when networking error happend in low level client(GSMClient)