### PR TITLE
#define BEAR_SSL_CLIENT_IOBUF_SIZE

### DIFF
--- a/src/BearSSLClient.h
+++ b/src/BearSSLClient.h
@@ -25,6 +25,10 @@
 #ifndef _BEAR_SSL_CLIENT_H_
 #define _BEAR_SSL_CLIENT_H_
 
+#ifndef BEAR_SSL_CLIENT_IOBUF_SIZE
+#define BEAR_SSL_CLIENT_IOBUF_SIZE 8192 + 85 + 325
+#endif
+
 #include <Arduino.h>
 #include <Client.h>
 
@@ -68,7 +72,7 @@ private:
 
   br_ssl_client_context _sc;
   br_x509_minimal_context _xc;
-  unsigned char _iobuf[8192 + 85 + 325];
+  unsigned char _iobuf[BEAR_SSL_CLIENT_IOBUF_SIZE];
   br_sslio_context _ioc;
 };
 


### PR DESCRIPTION
add BEAR_SSL_CLIENT_IOBUF_SIZE so that user can define it as a build option to have different IOBUF_SIZE