### PR TITLE
Allow built-in trust anchors to be overrided via constructor

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -31,7 +31,14 @@
 #include "BearSSLClient.h"
 
 BearSSLClient::BearSSLClient(Client& client) :
-  _client(&client)
+  BearSSLClient(client, TAs, TAs_NUM)
+{
+}
+
+BearSSLClient::BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs) :
+  _client(&client),
+  _TAs(myTAs),
+  _numTAs(myNumTAs)
 {
   _ecKey.curve = 0;
   _ecKey.x = NULL;
@@ -234,7 +241,7 @@ void BearSSLClient::setEccSlot(int ecc508KeySlot, const char cert[])
 int BearSSLClient::connectSSL(const char* host)
 {
   // initialize client context with all algorithms and hardcoded trust anchors
-  br_ssl_client_init_full(&_sc, &_xc, TAs, TAs_NUM);
+  br_ssl_client_init_full(&_sc, &_xc, _TAs, _numTAs);
 
   // set the buffer in split mode
   br_ssl_engine_set_buffer(&_sc.eng, _iobuf, sizeof(_iobuf), 1);

--- a/src/BearSSLClient.h
+++ b/src/BearSSLClient.h
@@ -38,6 +38,7 @@ class BearSSLClient : public Client {
 
 public:
   BearSSLClient(Client& client);
+  BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs);
   virtual ~BearSSLClient();
 
   virtual int connect(IPAddress ip, uint16_t port);
@@ -65,7 +66,10 @@ private:
   static void clientAppendCert(void *ctx, const void *data, size_t len);
 
 private:
-  Client* _client;  
+  Client* _client;
+  const br_x509_trust_anchor* _TAs;
+  int _numTAs;
+
   br_ec_private_key _ecKey;
   br_x509_certificate _ecCert;
   bool _ecCertDynamic;


### PR DESCRIPTION
An alternative proposal for #14.