### PR TITLE
Use two buffers instead of one buffer in split mode

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -248,8 +248,7 @@ int BearSSLClient::connectSSL(const char* host)
   // initialize client context with all algorithms and hardcoded trust anchors
   br_ssl_client_init_full(&_sc, &_xc, _TAs, _numTAs);
 
-  // set the buffer in split mode
-  br_ssl_engine_set_buffer(&_sc.eng, _iobuf, sizeof(_iobuf), 1);
+  br_ssl_engine_set_buffers_bidi(&_sc.eng, _ibuf, sizeof(_ibuf), _obuf, sizeof(_obuf));
 
   // inject entropy in engine
   unsigned char entropy[32];

--- a/src/BearSSLClient.h
+++ b/src/BearSSLClient.h
@@ -25,8 +25,12 @@
 #ifndef _BEAR_SSL_CLIENT_H_
 #define _BEAR_SSL_CLIENT_H_
 
-#ifndef BEAR_SSL_CLIENT_IOBUF_SIZE
-#define BEAR_SSL_CLIENT_IOBUF_SIZE 8192 + 85 + 325
+#ifndef BEAR_SSL_CLIENT_OBUF_SIZE
+#define BEAR_SSL_CLIENT_OBUF_SIZE 512 + 85
+#endif
+
+#ifndef BEAR_SSL_CLIENT_IBUF_SIZE
+#define BEAR_SSL_CLIENT_IBUF_SIZE 8192 + 85 + 325 - BEAR_SSL_CLIENT_OBUF_SIZE
 #endif
 
 #include <Arduino.h>
@@ -78,7 +82,8 @@ private:
 
   br_ssl_client_context _sc;
   br_x509_minimal_context _xc;
-  unsigned char _iobuf[BEAR_SSL_CLIENT_IOBUF_SIZE];
+  unsigned char _ibuf[BEAR_SSL_CLIENT_IBUF_SIZE];
+  unsigned char _obuf[BEAR_SSL_CLIENT_OBUF_SIZE];
   br_sslio_context _ioc;
 };
 


### PR DESCRIPTION
Use two dedicated buffers for input and output instead of split mode,
indeed some MQTT server (especially with TLS) needs a full 8k buffer as
they send their Certificate Chain. On the other hand, on output, a 1k
buffer seems to be enough

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>