### PR TITLE
Add support for not sending any SNI

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -31,14 +31,25 @@
 #include "BearSSLClient.h"
 
 BearSSLClient::BearSSLClient(Client& client) :
-  BearSSLClient(client, TAs, TAs_NUM)
+  BearSSLClient(client, TAs, TAs_NUM, false)
+{
+}
+
+BearSSLClient::BearSSLClient(Client& client, bool noSNI) :
+  BearSSLClient(client, TAs, TAs_NUM, noSNI)
 {
 }
 
 BearSSLClient::BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs) :
+  BearSSLClient(client, TAs, TAs_NUM, false)
+{
+}
+
+BearSSLClient::BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs, bool noSNI) :
   _client(&client),
   _TAs(myTAs),
-  _numTAs(myNumTAs)
+  _numTAs(myNumTAs),
+  _noSNI(noSNI)
 {
   _ecKey.curve = 0;
   _ecKey.x = NULL;
@@ -72,7 +83,7 @@ int BearSSLClient::connect(const char* host, uint16_t port)
     return 0;
   }
 
-  return connectSSL(host);
+  return connectSSL(_noSNI ? NULL : host);
 }
 
 size_t BearSSLClient::write(uint8_t b)

--- a/src/BearSSLClient.h
+++ b/src/BearSSLClient.h
@@ -38,7 +38,9 @@ class BearSSLClient : public Client {
 
 public:
   BearSSLClient(Client& client);
+  BearSSLClient(Client& client, bool noSNI);
   BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs);
+  BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs, bool noSNI);
   virtual ~BearSSLClient();
 
   virtual int connect(IPAddress ip, uint16_t port);
@@ -71,6 +73,8 @@ private:
   Client* _client;
   const br_x509_trust_anchor* _TAs;
   int _numTAs;
+
+  bool _noSNI;
 
   br_ec_private_key _ecKey;
   br_x509_certificate _ecCert;


### PR DESCRIPTION
Add support for not sending [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication) even when host is a DNS name.

This PR paves the way for supporting TLS servers with home-made/self-created PKI CAs and no SNI extension in server certificate.

This PR has been tested on an Arduino MKR WiFi 1000 and an Arduino MKR WiFi 1010 connected to an in-house MQTT/S broker ([mosquitto](https://mosquitto.org/)) with TLS support configured with security files generated via an in-house [EasyRSA](https://github.com/OpenVPN/easy-rsa) instance.

The Arduino boards have been programmed with the [AWS_IoT_WiFi.ino](https://github.com/arduino/ArduinoCloudProviderExamples/blob/master/examples/AWS%20IoT/AWS_IoT_WiFi/AWS_IoT_WiFi.ino) sketch.

Certificates generation steps:
  * the certificate signing requests (CSRs) have been generated with the standard [ArduinoECCX08 CSR tool](https://github.com/arduino-libraries/ArduinoECCX08/blob/master/examples/Tools/ECCX08CSR/ECCX08CSR.ino)
  * the CSRs have been signed with the in-house EasyRSA to generate the client certificates for the Arduino boards
  * the generated certificates have been added to the sketches.