### PR TITLE
Add CI status badges to readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,10 @@
-= ArduinoBearSSL =
+:repository-owner: arduino-libraries
+:repository-name: ArduinoBearSSL
+
+= {repository-name} =
+
+image:https://github.com/{repository-owner}/{repository-name}/workflows/Compile%20Examples/badge.svg["Compile Examples Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Compile+Examples"]
+image:https://github.com/{repository-owner}/{repository-name}/workflows/Spell%20Check/badge.svg["Spell Check Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Spell+Check"]
 
 Port of https://bearssl.org[BearSSL] to Arduino.
 


### PR DESCRIPTION
These badges show the status of the most recent CI workflow runs for the default branch.

Fixes https://github.com/arduino-libraries/ArduinoBearSSL/issues/27 (sorry, I always forget the badges)