### PR TITLE
Adding an additional BearSSL constructor as well as a method setClient to allow late initialisation.

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -31,12 +31,17 @@
 #include "BearSSLClient.h"
 
 BearSSLClient::BearSSLClient(Client& client) :
-  BearSSLClient(client, TAs, TAs_NUM)
+  BearSSLClient(&client, TAs, TAs_NUM)
 {
 }
 
-BearSSLClient::BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs) :
-  _client(&client),
+BearSSLClient::BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs)
+: BearSSLClient(&client, myTAs, myNumTAs)
+{
+}
+
+BearSSLClient::BearSSLClient(Client* client, const br_x509_trust_anchor* myTAs, int myNumTAs) :
+  _client(client),
   _TAs(myTAs),
   _numTAs(myNumTAs),
   _noSNI(false)

--- a/src/BearSSLClient.h
+++ b/src/BearSSLClient.h
@@ -43,7 +43,12 @@ class BearSSLClient : public Client {
 public:
   BearSSLClient(Client& client);
   BearSSLClient(Client& client, const br_x509_trust_anchor* myTAs, int myNumTAs);
+  BearSSLClient(Client* client, const br_x509_trust_anchor* myTAs, int myNumTAs);
   virtual ~BearSSLClient();
+
+
+  inline void setClient(Client& client) { _client = &client; }
+
 
   virtual int connect(IPAddress ip, uint16_t port);
   virtual int connect(const char* host, uint16_t port);


### PR DESCRIPTION
This allows for the ArduinoIoTCloud firmware to intantiate ArduinoBearSSL on the stack instead of the heap.