### PR TITLE
Allow the user to set his own client certificate

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -205,6 +205,11 @@ void BearSSLClient::setEccSign(br_ecdsa_sign sign)
   _ecSign = sign;
 }
 
+void BearSSLClient::setEccCert(br_x509_certificate cert)
+{
+  _ecCert = cert;
+}
+
 void BearSSLClient::setEccSlot(int ecc508KeySlot, const byte cert[], int certLength)
 {
   // HACK: put the key slot info. in the br_ec_private_key structure

--- a/src/BearSSLClient.h
+++ b/src/BearSSLClient.h
@@ -74,6 +74,8 @@ public:
   void setEccVrfy(br_ecdsa_vrfy vrfy);
   void setEccSign(br_ecdsa_sign sign);
 
+  void setEccCert(br_x509_certificate cert);
+
   void setEccSlot(int ecc508KeySlot, const byte cert[], int certLength);
   void setEccSlot(int ecc508KeySlot, const char cert[]);
 


### PR DESCRIPTION
This will allow the user to use ArduinoBearSSL without the ECCX08 (for
example with an (e)SIM applet compliant to the new GSMA IoT SAFE standard)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>