### PR TITLE
Adding symmetric encryption

### DIFF
--- a/examples/AES128/AES128.ino
+++ b/examples/AES128/AES128.ino
@@ -1,0 +1,64 @@
+/*
+  ArduinoCrypto AES128 Example
+
+  This sketch demonstrates how to run AES128 encryption and decryption for an input string.
+
+  Circuit:
+  - Nano 33 IoT board
+
+  created 13 July 2020
+  by Luigi Gubello
+
+  This example code is in the public domain.
+*/
+
+#include <ArduinoBearSSL.h>
+
+uint8_t key[16] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x02};
+uint8_t enc_iv[16] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x01,0x01};
+uint8_t dec_iv[16] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x01,0x01};
+uint8_t input[16] = "ArduinoArduino"; // {0x41,0x72,0x64,0x75,0x69,0x6E,0x6F,0x41,0x72,0x64,0x75,0x69,0x6E,0x6F,0x00,0x00}
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial);
+}
+
+void loop() {
+
+  Serial.print("Key: ");
+  printHex(key, 16);
+  Serial.println(" ");
+  Serial.print("IV: ");
+  printHex(enc_iv, 16);
+  Serial.println(" ");
+  Serial.print("AES128 Encryption of '");
+  printHex(input, 16);
+  Serial.print("' is 0x");
+  AES128.runEnc(key, 16, input, 16, enc_iv);   // expect 0x65D0F7758B094114AFA6D33A5EA0716A
+  printHex(input, 16);
+  Serial.println(" ");
+  Serial.println(" ");
+  Serial.print("Key: ");
+  printHex(key, 16);
+  Serial.println(" ");
+  Serial.print("IV: ");
+  printHex(dec_iv, 16);
+  Serial.println(" ");
+  Serial.print("AES128 Decryption of '");
+  printHex(input, 16);
+  Serial.print("' is 0x");
+  AES128.runDec(key, 16, input, 16, dec_iv);
+  printHex(input, 16);
+  Serial.println(" ");
+  while (1);
+}
+
+void printHex(uint8_t *text, size_t size) {
+  for (byte i = 0; i < size; i = i + 1) {
+    if (text[i] < 16) {
+      Serial.print("0");
+    }
+    Serial.print(text[i], HEX);
+  }
+}

--- a/examples/DES/DES.ino
+++ b/examples/DES/DES.ino
@@ -1,0 +1,64 @@
+/*
+  ArduinoCrypto DES Example
+
+  This sketch demonstrates how to run DES encryption and decryption for an input string.
+
+  Circuit:
+  - Nano 33 IoT board
+
+  created 13 July 2020
+  by Luigi Gubello
+
+  This example code is in the public domain.
+*/
+
+#include <ArduinoBearSSL.h>
+
+uint8_t key[8] = {0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x02};
+uint8_t enc_iv[8] = {0x00,0x00,0x00,0x00,0x00,0x01,0x01,0x01};
+uint8_t dec_iv[8] = {0x00,0x00,0x00,0x00,0x00,0x01,0x01,0x01};
+uint8_t input[8] = "Arduino"; // {0x41,0x72,0x64,0x75,0x69,0x6E,0x6F,0x00}
+
+void setup() {
+  Serial.begin(9600);
+  while (!Serial);
+}
+
+void loop() {
+
+  Serial.print("Key: ");
+  printHex(key, 8);
+  Serial.println(" ");
+  Serial.print("IV: ");
+  printHex(enc_iv, 8);
+  Serial.println(" ");
+  Serial.print("DES Encryption of '");
+  printHex(input, 8);
+  Serial.print("' is 0x");
+  DES.runEnc(key, 8, input, 8, enc_iv);   // expect 0x3C21EB6A62D372DB
+  printHex(input, 8);
+  Serial.println(" ");
+  Serial.println(" ");
+  Serial.print("Key: ");
+  printHex(key, 8);
+  Serial.println(" ");
+  Serial.print("IV: ");
+  printHex(dec_iv, 8);
+  Serial.println(" ");
+  Serial.print("DES Decryption of '");
+  printHex(input, 8);
+  Serial.print("' is 0x");
+  DES.runDec(key, 8, input, 8, dec_iv);
+  printHex(input, 8);
+  Serial.println(" ");
+  while (1);
+}
+
+void printHex(uint8_t *text, size_t size) {
+  for (byte i = 0; i < size; i = i + 1) {
+    if (text[i] < 16) {
+      Serial.print("0");
+    }
+    Serial.print(text[i], HEX);
+  }
+}

--- a/src/AES128.cpp
+++ b/src/AES128.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Arduino SA. All rights reserved.
+ * Copyright (c) 2019 Arduino SA. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining 
  * a copy of this software and associated documentation files (the
@@ -22,27 +22,31 @@
  * SOFTWARE.
  */
 
-#ifndef _ARDUINO_BEAR_SSL_H_
-#define _ARDUINO_BEAR_SSL_H_
-
-#include "BearSSLClient.h"
-#include "SHA1.h"
-#include "SHA256.h"
-#include "MD5.h"
 #include "AES128.h"
 
-class ArduinoBearSSLClass {
-public:
-  ArduinoBearSSLClass();
-  virtual ~ArduinoBearSSLClass();
+AES128Class::AES128Class() :
+  EncryptionClass(AES128_BLOCK_SIZE, AES128_DIGEST_SIZE)
+{
+}
 
-  unsigned long getTime();
-  void onGetTime(unsigned long(*)(void));
+AES128Class::~AES128Class()
+{
+}
 
-private:
-  unsigned long (*_onGetTimeCallback)(void);
-};
+int AES128Class::runEncryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv)
+{
+  br_aes_ct_cbcenc_init(&cbcenc_ctx, key, size);
+  br_aes_ct_cbcenc_run(&cbcenc_ctx, iv, input, block_size); // block_size must be multiple of 16
 
-extern ArduinoBearSSLClass ArduinoBearSSL;
+  return 1;
+}
 
-#endif
+int AES128Class::runDecryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv)
+{
+  br_aes_ct_cbcdec_init(&cbcdec_ctx, key, size);
+  br_aes_ct_cbcdec_run(&cbcdec_ctx, iv, input, block_size); // block_size must be multiple of 16
+
+  return 1;
+}
+
+AES128Class AES128;

--- a/src/AES128.h
+++ b/src/AES128.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Arduino SA. All rights reserved.
+ * Copyright (c) 2019 Arduino SA. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining 
  * a copy of this software and associated documentation files (the
@@ -22,27 +22,31 @@
  * SOFTWARE.
  */
 
-#ifndef _ARDUINO_BEAR_SSL_H_
-#define _ARDUINO_BEAR_SSL_H_
+#ifndef AES128_H
+#define AES128_H
 
-#include "BearSSLClient.h"
-#include "SHA1.h"
-#include "SHA256.h"
-#include "MD5.h"
-#include "AES128.h"
+#include <bearssl/bearssl_block.h>
 
-class ArduinoBearSSLClass {
+#include "Encryption.h"
+
+#define AES128_BLOCK_SIZE 16
+#define AES128_DIGEST_SIZE 16
+
+class AES128Class: public EncryptionClass {
+
 public:
-  ArduinoBearSSLClass();
-  virtual ~ArduinoBearSSLClass();
+  AES128Class();
+  virtual ~AES128Class();
 
-  unsigned long getTime();
-  void onGetTime(unsigned long(*)(void));
+protected:
+  virtual int runEncryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv);
+  virtual int runDecryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv);
 
 private:
-  unsigned long (*_onGetTimeCallback)(void);
+  br_aes_ct_cbcenc_keys cbcenc_ctx;
+  br_aes_ct_cbcdec_keys cbcdec_ctx;
 };
 
-extern ArduinoBearSSLClass ArduinoBearSSL;
+extern AES128Class AES128;
 
 #endif

--- a/src/DES.cpp
+++ b/src/DES.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Arduino SA. All rights reserved.
+ * Copyright (c) 2019 Arduino SA. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining 
  * a copy of this software and associated documentation files (the
@@ -22,28 +22,31 @@
  * SOFTWARE.
  */
 
-#ifndef _ARDUINO_BEAR_SSL_H_
-#define _ARDUINO_BEAR_SSL_H_
-
-#include "BearSSLClient.h"
-#include "SHA1.h"
-#include "SHA256.h"
-#include "MD5.h"
-#include "AES128.h"
 #include "DES.h"
 
-class ArduinoBearSSLClass {
-public:
-  ArduinoBearSSLClass();
-  virtual ~ArduinoBearSSLClass();
+DESClass::DESClass() :
+  EncryptionClass(DES_BLOCK_SIZE, DES_DIGEST_SIZE)
+{
+}
 
-  unsigned long getTime();
-  void onGetTime(unsigned long(*)(void));
+DESClass::~DESClass()
+{
+}
 
-private:
-  unsigned long (*_onGetTimeCallback)(void);
-};
+int DESClass::runEncryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv)
+{
+  br_des_ct_cbcenc_init(&cbcenc_ctx, key, size);
+  br_des_ct_cbcenc_run(&cbcenc_ctx, iv, input, block_size); // block_size must be multiple of 8
 
-extern ArduinoBearSSLClass ArduinoBearSSL;
+  return 1;
+}
 
-#endif
+int DESClass::runDecryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv)
+{
+  br_des_ct_cbcdec_init(&cbcdec_ctx, key, size);
+  br_des_ct_cbcdec_run(&cbcdec_ctx, iv, input, block_size); // block_size must be multiple of 8
+
+  return 1;
+}
+
+DESClass DES;

--- a/src/DES.h
+++ b/src/DES.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Arduino SA. All rights reserved.
+ * Copyright (c) 2019 Arduino SA. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining 
  * a copy of this software and associated documentation files (the
@@ -22,28 +22,31 @@
  * SOFTWARE.
  */
 
-#ifndef _ARDUINO_BEAR_SSL_H_
-#define _ARDUINO_BEAR_SSL_H_
+#ifndef DES_H
+#define DES_H
 
-#include "BearSSLClient.h"
-#include "SHA1.h"
-#include "SHA256.h"
-#include "MD5.h"
-#include "AES128.h"
-#include "DES.h"
+#include <bearssl/bearssl_block.h>
 
-class ArduinoBearSSLClass {
+#include "Encryption.h"
+
+#define DES_BLOCK_SIZE 8
+#define DES_DIGEST_SIZE 8
+
+class DESClass: public EncryptionClass {
+
 public:
-  ArduinoBearSSLClass();
-  virtual ~ArduinoBearSSLClass();
+  DESClass();
+  virtual ~DESClass();
 
-  unsigned long getTime();
-  void onGetTime(unsigned long(*)(void));
+protected:
+  virtual int runEncryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv);
+  virtual int runDecryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv);
 
 private:
-  unsigned long (*_onGetTimeCallback)(void);
+  br_des_ct_cbcenc_keys cbcenc_ctx;
+  br_des_ct_cbcdec_keys cbcdec_ctx;
 };
 
-extern ArduinoBearSSLClass ArduinoBearSSL;
+extern DESClass DES;
 
 #endif

--- a/src/Encryption.cpp
+++ b/src/Encryption.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019 Arduino SA. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining 
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be 
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "Encryption.h"
+
+EncryptionClass::EncryptionClass(int blockSize, int digestSize) :
+  _blockSize(blockSize),
+  _digestSize(digestSize)
+{
+  _data = (uint8_t*)malloc(_digestSize);
+  _secret = (uint8_t*)malloc(_blockSize);
+  _ivector = (uint8_t*)malloc(_blockSize);
+}
+
+EncryptionClass::~EncryptionClass()
+{
+  if (_secret) {
+    free(_secret);
+    _secret = NULL;
+  }
+
+  if (_data) {
+    free(_data);
+    _data = NULL;
+  }
+
+  if (_ivector) {
+    free(_ivector);
+    _ivector = NULL;
+  }
+}
+
+int EncryptionClass::runEnc(uint8_t *_secret, size_t _secretLength, uint8_t *_data, size_t _dataLength, uint8_t *_ivector)
+{
+  return runEncryption(_secret, _secretLength, _data, _dataLength, _ivector);
+}
+
+int EncryptionClass::runDec(uint8_t *_secret, size_t _secretLength, uint8_t *_data, size_t _dataLength, uint8_t *_ivector)
+{
+  return runDecryption(_secret, _secretLength, _data, _dataLength, _ivector);
+}

--- a/src/Encryption.h
+++ b/src/Encryption.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 Arduino SA. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining 
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be 
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef ENCRYPTION_H
+#define ENCRYPTION_H
+
+#include <Arduino.h>
+
+class EncryptionClass {
+
+public:
+  EncryptionClass(int blockSize, int digestSize);
+  virtual ~EncryptionClass();
+
+  int runEnc(uint8_t *_secret, size_t _secretLength, uint8_t *_data, size_t _dataLength, uint8_t *_ivector);
+  int runDec(uint8_t *_secret, size_t _secretLength, uint8_t *_data, size_t _dataLength, uint8_t *_ivector);
+
+protected:
+  virtual int runEncryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv) = 0;
+  virtual int runDecryption(uint8_t *key, size_t size, uint8_t *input, size_t block_size, uint8_t *iv) = 0;
+
+private:
+  int _blockSize;
+  int _digestSize;
+
+  uint8_t* _secret;
+  int _secretLength;
+  uint8_t* _ivector;
+  int _ivectorLength;
+  uint8_t* _data;
+  int _dataLength;
+};
+
+#endif


### PR DESCRIPTION
I have added user-friendly (I hope) support to symmetric encryption. In particular, you can run DES and AES128 now.

## How to use

### AES128

#### `runEnc()`

Giving the secret key, the initialization vector and the plain text, this method returns the encrypted one.

**Syntax**

`AES128.runEnc(key, keyLength, input, inputLengh, iv);`

**Parameters**

 - *key*: the secret key used to encrypt the plain text. The variable type is `uint8_t`;
 - *keyLength*: the secret key's length. It is *always* 16. The variable type is `size_t`;
 - *input*: the plain text. The variable type is `uint8_t`;
 - *inputLengh*: the plain text's length. It must be *always* a multiple of 16. The variable type is `size_t`;
 - *iv*: the initialization vector. It must have *always* 16 bytes. The variable type is `uint8_t`;

**Example**

```
#include <ArduinoBearSSL.h>
uint8_t key[16] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x02};
uint8_t iv[16] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x01,0x01};
uint8_t input[16] = "ArduinoArduino";
void setup() {
  AES128.runEnc(key, 16, input, 16, iv);
}
void loop() {}
```

#### `runDec()`

Giving the secret key, the initialization vector and the encrypted text, this method returns the decrypted one.

**Sintax**

`AES128.runDec(key, keyLength, input, inputLengh, iv);`

**Parameters**

 - *key*: the secret key used to encrypt the plain text. The variable type is `uint8_t`;
 - *keyLength*: the secret key's length. It is *always* 16. The variable type is `size_t`;
 - *input*: the encrypted text. The variable type is `uint8_t`;
 - *inputLengh*: the encrypted text's length. It must be *always* a multiple of 16. The variable type is `size_t`;
 - *iv*: the initialization vector. It must have *always* 16 bytes. The variable type is `uint8_t`;

**Example**

```
#include <ArduinoBearSSL.h>
uint8_t key[16] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x02};
uint8_t iv[16] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x01,0x01};
uint8_t input[16] = {0x65,0xD0,0xF7,0x75,0x8B,0x09,0x41,0x14,0xAF,0xA6,0xD3,0x3A,0x5E,0xA0,0x71,0x6A};
void setup() {
  AES128.runDec(key, 16, input, 16, iv);
}
void loop() {}
```

(similar for *DES*)

I have tested the examples with Arduino Nano 33 IoT (SAMD21), Arduino Uno WiFi Rev2 (ATmega4809) and Arduino Nano 33 BLE Sense.