### PR TITLE
Adding runHash method

### DIFF
--- a/src/MD5.cpp
+++ b/src/MD5.cpp
@@ -54,4 +54,13 @@ int MD5Class::end(uint8_t *digest)
   return 1;
 }
 
+int MD5Class::run(uint8_t *input, size_t size, uint8_t *output)
+{
+  br_md5_init(&_ctx);
+  br_md5_update(&_ctx, input, size);
+  br_md5_out(&_ctx, output);
+
+  return 1;
+}
+
 MD5Class MD5;

--- a/src/MD5.h
+++ b/src/MD5.h
@@ -42,6 +42,7 @@ protected:
   virtual int begin();
   virtual int update(const uint8_t *buffer, size_t size);
   virtual int end(uint8_t *digest);
+  virtual int run(uint8_t *input, size_t size, uint8_t *output);
 
 private:
   br_md5_context _ctx;

--- a/src/SHA.cpp
+++ b/src/SHA.cpp
@@ -64,6 +64,11 @@ int SHAClass::endHash()
   }
 }
 
+int HashClass::runHash(uint8_t *_secret, size_t _secretLength, uint8_t *_digest)
+{
+  return run(_secret, _secretLength, _digest);
+}
+
 int SHAClass::beginHmac(const String& secret)
 {
   return beginHmac((const uint8_t*)secret.c_str(), secret.length());

--- a/src/SHA.cpp
+++ b/src/SHA.cpp
@@ -64,7 +64,7 @@ int SHAClass::endHash()
   }
 }
 
-int HashClass::runHash(uint8_t *_secret, size_t _secretLength, uint8_t *_digest)
+int SHAClass::runHash(uint8_t *_secret, size_t _secretLength, uint8_t *_digest)
 {
   return run(_secret, _secretLength, _digest);
 }

--- a/src/SHA.h
+++ b/src/SHA.h
@@ -35,6 +35,7 @@ public:
 
   int beginHash();
   int endHash();
+  int runHash(uint8_t *_secret, size_t _secretLength, uint8_t *_digest);
 
   int beginHmac(const String& secret);
   int beginHmac(const char* secret);
@@ -58,6 +59,7 @@ protected:
   virtual int begin() = 0;
   virtual int update(const uint8_t *buffer, size_t size) = 0;
   virtual int end(uint8_t *digest) = 0;
+  virtual int run(uint8_t *input, size_t size, uint8_t *output) = 0;
 
 private:
   int _blockSize;

--- a/src/SHA1.cpp
+++ b/src/SHA1.cpp
@@ -54,4 +54,13 @@ int SHA1Class::end(uint8_t *digest)
   return 1;
 }
 
+int SHA1Class::run(uint8_t *input, size_t size, uint8_t *output)
+{
+  br_sha1_init(&_ctx);
+  br_sha1_update(&_ctx, input, size);
+  br_sha1_out(&_ctx, output);
+
+  return 1;
+}
+
 SHA1Class SHA1;

--- a/src/SHA1.h
+++ b/src/SHA1.h
@@ -42,6 +42,7 @@ protected:
   virtual int begin();
   virtual int update(const uint8_t *buffer, size_t size);
   virtual int end(uint8_t *digest);
+  virtual int run(uint8_t *input, size_t size, uint8_t *output);
 
 private:
   br_sha1_context _ctx;

--- a/src/SHA256.cpp
+++ b/src/SHA256.cpp
@@ -54,4 +54,13 @@ int SHA256Class::end(uint8_t *digest)
   return 1;
 }
 
+int SHA256Class::run(uint8_t *input, size_t size, uint8_t *output)
+{
+  br_sha256_init(&_ctx);
+  br_sha256_update(&_ctx, input, size);
+  br_sha256_out(&_ctx, output);
+
+  return 1;
+}
+
 SHA256Class SHA256;

--- a/src/SHA256.h
+++ b/src/SHA256.h
@@ -42,6 +42,7 @@ protected:
   virtual int begin();
   virtual int update(const uint8_t *buffer, size_t size);
   virtual int end(uint8_t *digest);
+  virtual int run(uint8_t *input, size_t size, uint8_t *output);
 
 private:
   br_sha256_context _ctx;


### PR DESCRIPTION
Cryptography is cool, but it is hard. I have added the method `runHash()` because I hope this is a user-friendly way to calculate a hash value. The user needs just to allocate memory for the output, give the input to `runHash()` and the method returns the output.

## How to use

### SHA256

#### `runHash()`

Giving the input text, this method returns the SHA256 hash.

**Sintax**

`SHA256.runHash(input, inputLength, output);`

**Parameters**

 - *input*: the plain text. The variable type is  `uint8_t`;
 - *inputLength*: the plain text's length. The variable type is `size_t`;
 - *output*: the SHA256 hash. It is *always* 32 bytes long. The variable type is `size_t`;

**Example**

```
#include <ArduinoBearSSL.h>
uint8_t input[8] = "Arduino";
uint8_t output[32];
void setup() {
  SHA256.runHash(input, 8, output);
}
void loop() {}
```

(similar for **MD5** and **SHA1**)