### PR TITLE
src/BearSSLClient.cpp: fix _ecSign

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -301,7 +301,7 @@ int BearSSLClient::connectSSL(const char* host)
   br_x509_minimal_set_ecdsa(&_xc, br_ssl_engine_get_ec(&_sc.eng), br_ssl_engine_get_ecdsa(&_sc.eng));
 
   // enable client auth
-  if (_ecCert.data_len && _ecKey.xlen) {
+  if (_ecCert.data_len) {
     br_ssl_client_set_single_ec(&_sc, &_ecCert, 1, &_ecKey, BR_KEYTYPE_KEYX | BR_KEYTYPE_SIGN, BR_KEYTYPE_EC, br_ec_get_default(), _ecSign);
   }
 


### PR DESCRIPTION
The client can specify its own `_ecSign` function since commit 996778e73d22093526b1b7126cf7bfc2499158b5 as well as its own certificate since commit 874c6b0c38ae2ad34a3388710961411e3a3aed5a.
The goal was to allow the user to use ArduinoBearSSL without the ECCX08 (for example with an (e)SIM applet compliant to the new GSMA IoT SAFE standard).

However, these two functions don't work because `br_ssl_client_set_single_ec` is not called if `_ecKey.xlen` is set to 0 so fix this latest issue

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>