### PR TITLE
Enable setting client certificate parent

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -47,8 +47,8 @@ BearSSLClient::BearSSLClient(Client* client, const br_x509_trust_anchor* myTAs, 
   _noSNI(false),
   _ecChainLen(0)
 {
-  _ecVrfy = br_ecdsa_vrfy_asn1_get_default();
-  _ecSign = br_ecdsa_sign_asn1_get_default();
+  _ecVrfy = eccX08_vrfy_asn1;
+  _ecSign = eccX08_sign_asn1;
 
   _ecKey.curve = 0;
   _ecKey.x = NULL;

--- a/src/BearSSLClient.h
+++ b/src/BearSSLClient.h
@@ -83,6 +83,7 @@ public:
 
   void setEccSlot(int ecc508KeySlot, const byte cert[], int certLength);
   void setEccSlot(int ecc508KeySlot, const char cert[]);
+  void setEccCertParent(const char cert[]);
 
   int errorCode();
 
@@ -91,6 +92,7 @@ private:
   static int clientRead(void *ctx, unsigned char *buf, size_t len);
   static int clientWrite(void *ctx, const unsigned char *buf, size_t len);
   static void clientAppendCert(void *ctx, const void *data, size_t len);
+  static void parentAppendCert(void *ctx, const void *data, size_t len);
 
 private:
   Client* _client;


### PR DESCRIPTION
This is similar to #39 in that it enables setting the parent certificate of a client certificate, but the difference to #39 is that it works when the client certificate private key is using an ECC508/608 key slot.

This change is based from #43 and with these two changes it makes it possible to use AWS JITP with an Arduino Nano 33 IoT with the private key stored in the ATECC608A.