### PR TITLE
Add ARDUINO_DISABLE_ECCX08

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,9 @@ image:https://github.com/{repository-owner}/{repository-name}/workflows/Spell%20
 
 Port of https://bearssl.org[BearSSL] to Arduino.
 
-This library depends on ArduinoECCX08.
+This library depends on ArduinoECCX08. This dependency could be
+disabled by defining ARDUINO_DISABLE_ECCX08 in ArduinoBearSSLConfig.h
+(see examples).
 
 == License ==
 

--- a/examples/AES128/ArduinoBearSSLConfig.h
+++ b/examples/AES128/ArduinoBearSSLConfig.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_BEARSSL_CONFIG_H_
+#define ARDUINO_BEARSSL_CONFIG_H_
+
+/* Enabling this define allows the usage of ArduinoBearSSL without crypto chip. */
+//#define ARDUINO_DISABLE_ECCX08
+
+#endif /* ARDUINO_BEARSSL_CONFIG_H_ */

--- a/examples/DES/ArduinoBearSSLConfig.h
+++ b/examples/DES/ArduinoBearSSLConfig.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_BEARSSL_CONFIG_H_
+#define ARDUINO_BEARSSL_CONFIG_H_
+
+/* Enabling this define allows the usage of ArduinoBearSSL without crypto chip. */
+//#define ARDUINO_DISABLE_ECCX08
+
+#endif /* ARDUINO_BEARSSL_CONFIG_H_ */

--- a/examples/MD5/ArduinoBearSSLConfig.h
+++ b/examples/MD5/ArduinoBearSSLConfig.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_BEARSSL_CONFIG_H_
+#define ARDUINO_BEARSSL_CONFIG_H_
+
+/* Enabling this define allows the usage of ArduinoBearSSL without crypto chip. */
+//#define ARDUINO_DISABLE_ECCX08
+
+#endif /* ARDUINO_BEARSSL_CONFIG_H_ */

--- a/examples/MKRGSMSSLClient/ArduinoBearSSLConfig.h
+++ b/examples/MKRGSMSSLClient/ArduinoBearSSLConfig.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_BEARSSL_CONFIG_H_
+#define ARDUINO_BEARSSL_CONFIG_H_
+
+/* Enabling this define allows the usage of ArduinoBearSSL without crypto chip. */
+//#define ARDUINO_DISABLE_ECCX08
+
+#endif /* ARDUINO_BEARSSL_CONFIG_H_ */

--- a/examples/SHA1/ArduinoBearSSLConfig.h
+++ b/examples/SHA1/ArduinoBearSSLConfig.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_BEARSSL_CONFIG_H_
+#define ARDUINO_BEARSSL_CONFIG_H_
+
+/* Enabling this define allows the usage of ArduinoBearSSL without crypto chip. */
+//#define ARDUINO_DISABLE_ECCX08
+
+#endif /* ARDUINO_BEARSSL_CONFIG_H_ */

--- a/examples/SHA256/ArduinoBearSSLConfig.h
+++ b/examples/SHA256/ArduinoBearSSLConfig.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_BEARSSL_CONFIG_H_
+#define ARDUINO_BEARSSL_CONFIG_H_
+
+/* Enabling this define allows the usage of ArduinoBearSSL without crypto chip. */
+//#define ARDUINO_DISABLE_ECCX08
+
+#endif /* ARDUINO_BEARSSL_CONFIG_H_ */

--- a/examples/WiFiSSLClient/ArduinoBearSSLConfig.h
+++ b/examples/WiFiSSLClient/ArduinoBearSSLConfig.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_BEARSSL_CONFIG_H_
+#define ARDUINO_BEARSSL_CONFIG_H_
+
+/* Enabling this define allows the usage of ArduinoBearSSL without crypto chip. */
+//#define ARDUINO_DISABLE_ECCX08
+
+#endif /* ARDUINO_BEARSSL_CONFIG_H_ */

--- a/examples/extras/WiFiSSLClientNoSNI/ArduinoBearSSLConfig.h
+++ b/examples/extras/WiFiSSLClientNoSNI/ArduinoBearSSLConfig.h
@@ -1,0 +1,7 @@
+#ifndef ARDUINO_BEARSSL_CONFIG_H_
+#define ARDUINO_BEARSSL_CONFIG_H_
+
+/* Enabling this define allows the usage of ArduinoBearSSL without crypto chip. */
+//#define ARDUINO_DISABLE_ECCX08
+
+#endif /* ARDUINO_BEARSSL_CONFIG_H_ */

--- a/src/ArduinoBearSSL.h
+++ b/src/ArduinoBearSSL.h
@@ -25,6 +25,12 @@
 #ifndef _ARDUINO_BEAR_SSL_H_
 #define _ARDUINO_BEAR_SSL_H_
 
+#if defined __has_include
+#  if __has_include (<ArduinoBearSSLConfig.h>)
+#    include <ArduinoBearSSLConfig.h>
+#  endif
+#endif
+
 #include "BearSSLClient.h"
 #include "SHA1.h"
 #include "SHA256.h"

--- a/src/utility/eccX08_sign_asn1.cpp
+++ b/src/utility/eccX08_sign_asn1.cpp
@@ -23,6 +23,9 @@
  * SOFTWARE.
  */
 
+#include "ArduinoBearSSL.h"
+
+#ifndef ARDUINO_DISABLE_ECCX08
 #include "eccX08_asn1.h"
 
 #include <ArduinoECCX08.h>
@@ -51,3 +54,4 @@ eccX08_sign_asn1(const br_ec_impl * /*impl*/,
   memcpy(sig, rsig, sig_len);
   return sig_len;
 }
+#endif

--- a/src/utility/eccX08_vrfy_asn1.cpp
+++ b/src/utility/eccX08_vrfy_asn1.cpp
@@ -23,6 +23,9 @@
  * SOFTWARE.
  */
 
+#include "ArduinoBearSSL.h"
+
+#ifndef ARDUINO_DISABLE_ECCX08
 #include "eccX08_asn1.h"
 
 #include <ArduinoECCX08.h>
@@ -60,3 +63,4 @@ eccX08_vrfy_asn1(const br_ec_impl * /*impl*/,
 
   return 1;
 }
+#endif


### PR DESCRIPTION
This new compilation flag can be set through ArduinoBearSSLConfig.h and
will allow the user to use ArduinoBearSSL without ECCX08.

Indeed, the cryptographic operations could be done through the default
software implementation or offloaded to another secure element such as
an applet compliant with the GSMA IoT SAFE standard.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>