### PR TITLE
fix write() in BearSSLClient.cpp

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -111,7 +111,7 @@ size_t BearSSLClient::write(const uint8_t *buf, size_t size)
   size_t written = 0;
 
   while (written < size) {
-    int result = br_sslio_write(&_ioc, buf, size);
+    int result = br_sslio_write(&_ioc, buf, size - written);
 
     if (result < 0) {
       break;


### PR DESCRIPTION
This PR resolves the issue(#60): failed to send a long date ( > 512 bytes ).

