### PR TITLE
Add configuration define to disable br_sslio_close

### DIFF
--- a/src/BearSSLClient.cpp
+++ b/src/BearSSLClient.cpp
@@ -203,10 +203,11 @@ void BearSSLClient::flush()
 void BearSSLClient::stop()
 {
   if (_client->connected()) {
+#if !defined(ARDUINO_BEARSSL_DISABLE_TLS_CLOSE)
     if ((br_ssl_engine_current_state(&_sc.eng) & BR_SSL_CLOSED) == 0) {
       br_sslio_close(&_ioc);
     }
-
+#endif
     _client->stop();
   }
 }


### PR DESCRIPTION
From BearSSL docs:

 br_sslio_close(): perform the SSL closure protocol. This entails sending a close_notify alert, and receiving a close_notify response.
 
Note that a number of deployed SSL implementations do not follow the protocol for closure, and may drop the underlying socket abruptly. As such, errors are often reported by br_sslio_close().
 
In case of mbed-os + ArduinoIoTCloud br_sslio_close is endless looping blocking sketch execution.