### PR TITLE
Zephyr support

### DIFF
--- a/src/bearssl/aes_pwr8.c
+++ b/src/bearssl/aes_pwr8.c
@@ -52,7 +52,7 @@ key_schedule_128(unsigned char *sk, const unsigned char *key)
 	 * of the computation is VMX only. VMX register 0 is VSX
 	 * register 32.
 	 */
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * v0 = all-zero word
@@ -161,7 +161,7 @@ key_schedule_192(unsigned char *sk, const unsigned char *key)
 	 * of the computation is VMX only. VMX register 0 is VSX
 	 * register 32.
 	 */
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * v0 = all-zero word
@@ -299,7 +299,7 @@ key_schedule_256(unsigned char *sk, const unsigned char *key)
 	 * of the computation is VMX only. VMX register 0 is VSX
 	 * register 32.
 	 */
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * v0 = all-zero word

--- a/src/bearssl/aes_pwr8_cbcdec.c
+++ b/src/bearssl/aes_pwr8_cbcdec.c
@@ -52,7 +52,7 @@ cbcdec_128(const unsigned char *sk,
 	cc1 = 16;
 	cc2 = 32;
 	cc3 = 48;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v10
@@ -223,7 +223,7 @@ cbcdec_192(const unsigned char *sk,
 	cc1 = 16;
 	cc2 = 32;
 	cc3 = 48;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v12
@@ -406,7 +406,7 @@ cbcdec_256(const unsigned char *sk,
 	cc1 = 16;
 	cc2 = 32;
 	cc3 = 48;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v14

--- a/src/bearssl/aes_pwr8_cbcenc.c
+++ b/src/bearssl/aes_pwr8_cbcenc.c
@@ -49,7 +49,7 @@ cbcenc_128(const unsigned char *sk,
 #endif
 
 	cc = 0;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v10
@@ -153,7 +153,7 @@ cbcenc_192(const unsigned char *sk,
 #endif
 
 	cc = 0;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v12
@@ -263,7 +263,7 @@ cbcenc_256(const unsigned char *sk,
 #endif
 
 	cc = 0;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v14

--- a/src/bearssl/aes_pwr8_ctr.c
+++ b/src/bearssl/aes_pwr8_ctr.c
@@ -55,7 +55,7 @@ ctr_128(const unsigned char *sk, const unsigned char *ivbuf,
 	cc1 = 16;
 	cc2 = 32;
 	cc3 = 48;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v10
@@ -239,7 +239,7 @@ ctr_192(const unsigned char *sk, const unsigned char *ivbuf,
 	cc1 = 16;
 	cc2 = 32;
 	cc3 = 48;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v12
@@ -435,7 +435,7 @@ ctr_256(const unsigned char *sk, const unsigned char *ivbuf,
 	cc1 = 16;
 	cc2 = 32;
 	cc3 = 48;
-	asm volatile (
+	__asm__ volatile (
 
 		/*
 		 * Load subkeys into v0..v14

--- a/src/bearssl/aes_pwr8_ctrcbc.c
+++ b/src/bearssl/aes_pwr8_ctrcbc.c
@@ -437,7 +437,7 @@ ctr_ ## size(const unsigned char *sk, \
 	cc1 = 16; \
 	cc2 = 32; \
 	cc3 = 48; \
-	asm volatile ( \
+	__asm__ volatile ( \
  \
 		/* \
 		 * Load subkeys into v0..v10 \
@@ -543,7 +543,7 @@ cbcmac_ ## size(const unsigned char *sk, \
 	long cc; \
  \
 	cc = 0; \
-	asm volatile ( \
+	__asm__ volatile ( \
  \
 		/* \
 		 * Load subkeys into v0..v10 \
@@ -603,7 +603,7 @@ ctrcbc_ ## size ## _encrypt(const unsigned char *sk, \
 	long cc; \
  \
 	cc = 0; \
-	asm volatile ( \
+	__asm__ volatile ( \
  \
 		/* \
 		 * Load subkeys into v0..v10 \
@@ -706,7 +706,7 @@ ctrcbc_ ## size ## _decrypt(const unsigned char *sk, \
 	long cc; \
  \
 	cc = 0; \
-	asm volatile ( \
+	__asm__ volatile ( \
  \
 		/* \
 		 * Load subkeys into v0..v10 \

--- a/src/bearssl/ghash_pwr8.c
+++ b/src/bearssl/ghash_pwr8.c
@@ -159,7 +159,7 @@ br_ghash_pwr8(void *y, const void *h, const void *data, size_t len)
 	cc1 = 16;
 	cc2 = 32;
 	cc3 = 48;
-	asm volatile (
+	__asm__ volatile (
 		INIT
 
 		/*

--- a/src/bearssl/i15_montmul.c
+++ b/src/bearssl/i15_montmul.c
@@ -25,6 +25,7 @@
 #include "inner.h"
 
 /* see inner.h */
+__attribute__((optimize("omit-frame-pointer")))
 void
 br_i15_montymul(uint16_t *d, const uint16_t *x, const uint16_t *y,
 	const uint16_t *m, uint16_t m0i)

--- a/src/bearssl/i15_montmul.c
+++ b/src/bearssl/i15_montmul.c
@@ -47,7 +47,7 @@ br_i15_montymul(uint16_t *d, const uint16_t *x, const uint16_t *y,
 			uint16_t *limit;
 
 			limit = d + len4;
-			asm volatile (
+			__asm__ volatile (
 "\n\
 	@ carry: r=r2                                              \n\
 	@ multipliers: xu=r3 f=r4                                  \n\


### PR DESCRIPTION
The following changes are required in order to make ArduinoBearSSL work on zephyr